### PR TITLE
Old links were updated and some links were removed

### DIFF
--- a/content/getting-started.md
+++ b/content/getting-started.md
@@ -1,6 +1,6 @@
 ---
 title: "Getting Started"
-date: 2017-08-12T00:16:49+05:30
+date: 2023-01-19T22:20:00+05:30
 url: /getting-started
 ---
 
@@ -10,93 +10,96 @@ GNU/Linux being the snowballing phenomenon it is, there are literally a billion 
 
 ## Where it all started:
 
-* [The Free Software Foundation](http://www.fsf.org/)
-* [The GNU Project](http://www.gnu.org/)
-* [The BSD Endeavor](http://www.bsd.org/)
-* [Open Source Initiative](http://www.opensource.org/)
-* [Electronic Frontier Foundation(EFF)](http://www.eff.org/)
-* [Creative Commons](http://creativecommons.org/)
-* [No Software Patents!](http://www.nosoftwarepatents.com/en/m/intro/index.html)
-* [Defective By Design](http://www.defectivebydesign.org/)
-* [Open Document Format](http://www.odfalliance.org/)
-* [Open Multimedia Format](http://www.xiph.org/)
+* [The Free Software Foundation](https://www.fsf.org/)
+* [The GNU Project](https://www.gnu.org/)
+* [The BSD Endeavor](https://www.bsd.org/)
+* [Open Source Initiative](https://www.opensource.org/)
+* [Electronic Frontier Foundation(EFF)](https://www.eff.org/)
+* [Creative Commons](https://creativecommons.org/)
+* [Defective By Design](https://www.defectivebydesign.org/)
+* [Open Document Format](https://www.odfalliance.org/)
+* [Open Multimedia Format](https://www.xiph.org/)
 * [Open Image Format](http://www.libpng.org/pub/png/)
 
 
 ## Where you should start:
 
-* [Linux.org](http://www.linux.org/)
-* [Linux.com](http://www.linux.com/)
-* [The Linux Documentation Project](http://www.tldp.org/)
-* [Linux Newbie’s Page](http://www.linuxnewbie.org/)
-* [ILUGC ODOC](http://www.livejournal.com/community/ilugc/)
+* [Linux.org](https://www.linux.org/)
+* [Linux.com](https://www.linux.com/)
+* [The Linux Documentation Project](https://www.tldp.org/)
+* [Linux Newbie’s Page](https://linuxnewbieguide.org/)
+* [ILUGC ODOC](https://www.livejournal.com/community/ilugc/)
 
 
 ## News sites:
 
-* [Slashdot](http://slashdot.org/)
-* [Linux Today](http://www.linuxtoday.com/)
-* [Linux World](http://www.linuxworld.com/)
-* [Linux Weekly News](http://lwn.net/)
+* [Slashdot](https://slashdot.org/)
+* [Linux Today](https://www.linuxtoday.com/)
+* [Linux World](https://www.networkworld.com/category/linux/)
+* [Linux Weekly News](https://lwn.net/)
 * [Daemon News](http://www.daemonnews.org/)
 
 
 ## E-zines:
 
 * [FSF Magazine](http://www.freesoftwaremagazine.com/)
-* [Linux For You](http://www.linuxforu.com/)
-* [Linux Gazette](http://www.linuxgazette.com/)
+* [Open Source For You](https://www.opensourceforu.com/)
+* [Linux Gazette](https://linuxgazette.net/)
 * [Linux Focus](http://www.linuxfocus.org/)
-* [Linux Magazine](http://www.linux-mag.com/)
-* [Linux Format](http://www.linuxformat.co.uk/)
-* [Linux Journal](http://www.linuxjournal.com/)
+* [Linux Magazine](https://www.linux-magazine.com/)
+* [Linux Format](https://www.linuxformat.co.uk/)
+* [Linux Journal](https://www.linuxjournal.com/)
 * [Ubuntu Magazine](http://fullcirclemagazine.org/)
-* [RedHat Magazine](http://magazine.redhat.com/)
+* [RedHat Magazine](https://magazine.redhat.com/)
+
 
 
 ## Which distribution should I use?
 
+* [Linux Mint](https://linuxmint.com/)
 * [Slackware](http://www.slackware.com/)
-* [Debian GNU/Linux](http://www.debian.org/)
-* [Fedora (RedHat)](http://www.fedora.org/)
-* [Ubuntu](http://www.ubuntu.com/)
-* [OpenSuSE](http://www.opensuse.org/)
-* [Mandriva Linux](http://www.mandriva.com/)
-* [Gentoo Linux](http://www.gentoo.org/)
-* [BOSS Linux](http://bosslinux.in/)
-* [FreeBSD](http://www.freebsd.org/)
-* ... [and many more](http://distrowatch.com/)
+* [Debian GNU/Linux](https://www.debian.org/)
+* [Fedora (RedHat)](https://getfedora.org/)
+* [Ubuntu](https://www.ubuntu.com/)
+* [OpenSuSE](https://www.opensuse.org/)
+* [Endeavor OS](https://endeavouros.com/)
+* [Gentoo Linux](https://www.gentoo.org/)
+* [BOSS Linux](https://bosslinux.in/)
+* [FreeBSD](https://www.freebsd.org/)
+* ... [and many more](https://distrowatch.com/)
 
 
 ## Graphical User Environments:
 
-* [X.Org](http://www.x.org/) – X Window System
+* [X.Org](https://www.x.org/) – X Window System
 * [XFree86](http://www.xfree86.org/) – X Window System
-* [GNOME](http://www.gnome.org/) – GNU Network Object Model Environment
-* [KDE](http://www.kde.org/) – K Desktop Environment
-* [XFCE](http://www.xfce.org/) – Light weight Window Manager
-* ... [and many more](http://www.plig.org/xwinman)
+* [GNOME](https://www.gnome.org/) – GNU Network Object Model Environment
+* [KDE](https://www.kde.org/) – K Desktop Environment
+* [XFCE](https://www.xfce.org/) – Light weight Window Manager
+* ... [and many more](http://www.xwinman.org/)
 
 
 ## What, no applications?
 
-* [FSF Resource](http://directory.fsf.org/)
-* [SourceForge](http://www.sf.net/)
-* [Freshmeat](http://freshmeat.net/)
+* [FSF Resource](https://directory.fsf.org/)
+* [SourceForge](https://sourceforge.net/)
+* [Freshmeat](https://freshmeat.net/)
 * [Savannah](http://savannah.nongnu.org/)
 
+## Few tamil open source and linux community
+
+* [Tamil Linux Community](https://forums.tamillinuxcommunity.org/)
+* [Villupuram GLUG](https://vglug.org/)
+* [KanchiLUG](https://kanchilug.wordpress.com/)
 
 ## FOSS Organizations in India
 
-* [FSF-India](http://www.gnu.org.in/)
-* [NRC-FOSS Helpline](http://nrcfosshelpline.in/)
-* [NRC-FOSS CDAC](http://nrcfoss.org.in/)
-* [NRC-FOSS AU-KBC](http://au-kbc.org/nrcfoss)
-* [OSSRC-India](http://www.ossrc.org.in/)
-* [ODF-India](http://www.ossrc.org.in/odf)
-* [FOSS.in Event](http://foss.in/)
-* [Public-Software India](http://www.public-software.in/)
-* [FOSS Community India](http://fci.wikia.com/wiki/Main_Page)
+* [FSF-India](https://www.gnu.org.in/)
+* [Kaniyam](https://www.kaniyam.com/)
+* [FOSS.in Event](https://en.wikipedia.org/wiki/FOSS.IN)
+* [Public-Software India](https://www.public-software.in/)
+* [FOSS Community India](https://fci.wikia.com/wiki/Main_Page)
+* [FSMI](https://fsmi.in/)
 
 
 ## Other ILUG’s
@@ -110,7 +113,7 @@ GNU/Linux being the snowballing phenomenon it is, there are literally a billion 
 * Kolkatta
 * Delhi
 * Pune
-* [Indian TeX Users Group](http://www.tug.org.in/)
+* [Indian TeX Users Group](https://www.tug.org/tutorials/tugindia/)
 
 
 Apart from this, many colleges run their local Users Groups to support the FOSS activities of their students.


### PR DESCRIPTION
Old http links were replaced with https 
Below links were removed not able to find new links

- [NRC-FOSS Helpline](http://nrcfosshelpline.in/)
- [NRC-FOSS CDAC](http://nrcfoss.org.in/)
- [NRC-FOSS AU-KBC](http://au-kbc.org/nrcfoss)
- [OSSRC-India](http://www.ossrc.org.in/)
- [ODF-India](http://www.ossrc.org.in/odf)
- [FOSS.in Event](http://foss.in/)

Some links were pointing to inappropirate website. So updated them with new or equivalent links
Added one more section for linux community and added kaniyam in FOSS organisation
Added linux mint and endeavour os for linux distro suggestion removed mandriva linux as it is pointing to a casino website